### PR TITLE
feat: separate node_count from node_count_min

### DIFF
--- a/pool/main.tf
+++ b/pool/main.tf
@@ -11,7 +11,7 @@ resource "google_container_node_pool" "pool" {
   }
 
   autoscaling {
-    min_node_count = var.node_count
+    min_node_count = var.node_count_min
     max_node_count = var.node_count_max
   }
 

--- a/pool/variables.tf
+++ b/pool/variables.tf
@@ -16,8 +16,8 @@ variable "node_count_max" {
   default     = 10
 }
 
-variable "node_count_max" {
-  description = "The max number of nodes to create in autoscaling mode"
+variable "node_count_min" {
+  description = "The min number of nodes to create in autoscaling mode"
   default     = 1
 }
 

--- a/pool/variables.tf
+++ b/pool/variables.tf
@@ -16,6 +16,11 @@ variable "node_count_max" {
   default     = 10
 }
 
+variable "node_count_max" {
+  description = "The max number of nodes to create in autoscaling mode"
+  default     = 1
+}
+
 variable "cluster" {
   description = "Name of the cluster to which to add this Node Pool"
 }


### PR DESCRIPTION
Allow scaling down to 1 node even if initial number of nodes was higher.